### PR TITLE
README: minor enhancements to the "Usage" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Based on [KeePassXC-Browser](https://github.com/keepassxreboot/keepassxc-browser
 
 *Hopefully we can get this as simple as for KeePassXC-Browser in the future.*
 
- 1. First the KeePassXC-Browser configuration (described in this [document](https://keepassxc.org/docs/keepassxc-browser-migration/)) has to be done.
- 2. Afterwards the configuration file for the Native Messaging has to be created.
- 3. At the end the addon can be installed in Thunderbird (download the latest xpi [here](https://github.com/kkapsner/keepassxc-mail/releases/latest)).
+ 1. Configure KeePassXC-Browser as described in [this document](https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_configure_keepassxc_browser). Make sure to enable the integration for Firefox.
+ 2. Create the configuration file for Native Messaging as described below in [Native Messaging configuration](#native-messaging-configuration).
+ 3. Install the add-on in Thunderbird. Either download the [latest prebuilt xpi](https://github.com/kkapsner/keepassxc-mail/releases/latest) or build it yourself (`npm install`, `npm run build`, the xpi will be in the `mail-ext-artifacts` directory).
 
 ## Native Messaging configuration
 


### PR DESCRIPTION
The link to the KeePassXC-Browser configuration documentation seems to have changed. Also rephrased the instructions a little bit and added short info on building the add-on, though for most users that'll hardly be necessary.

Feel free to just grab the updated link if you don't like the rest of the changes (I think that the note to enable Firefox integration is also important—not sure if it's turned on by default on new clean installs of KeePassXC).

Last but not least, thank you very much for undertaking this project—it's really a lifesaver for many of us!