### PR TITLE
Add mailbox:// to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ KeePassXC-Mail uses the following schema to find matching entries for a given se
  * `imap://{server name}`
  * `smtp://{server name}`
  * `pop3://{server name}`
+ * `mailbox://{server name}`
  * `http://{server name}`
  * `https://{server name}`
  * `nntp-1://{server name}`


### PR DESCRIPTION
Since I updated to Thunderbid 78 the prefix for POP3 seems to be mailbox://, not pop3:// anymore.